### PR TITLE
docs: clarify initial workflow expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+## Working Style
+
+For now, keep the workflow lightweight:
+
+- keep `main` stable
+- make changes in short-lived branches
+- open small pull requests with clear intent
+- prefer incremental updates over large batch changes
+
+This is only a starting point and can evolve as the repo grows.


### PR DESCRIPTION
Adds a short working-style section to the README so early collaboration has a simple default workflow.