### PR TITLE
docs: add collaboration reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Collaboration Reminder
+
+A simple default workflow for now:
+
+- keep `main` stable
+- use short-lived branches
+- open focused pull requests


### PR DESCRIPTION
Adds a short collaboration reminder to the README so the repo has a lightweight default workflow.